### PR TITLE
Fixed: Typo in Exemple 3.23. Formatting Numbers

### DIFF
--- a/native_data_types/formatting_strings.html
+++ b/native_data_types/formatting_strings.html
@@ -1,4 +1,3 @@
-
 <!DOCTYPE html
   PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
 <html>
@@ -141,11 +140,11 @@ TypeError: cannot concatenate 'str' and 'int' objects</span></pre><div class="ca
          </p>
 <div class="example"><a name="odbchelper.stringformatting.numbers"></a><h3 class="title">Example&nbsp;3.23.&nbsp;Formatting Numbers</h3><pre class="screen">
 <tt class="prompt">&gt;&gt;&gt; </tt><span class="userinput"><span class="pykeyword">print</span> <span class="pystring">"Today's stock price: %f"</span> % 50.4625</span>   <a name="odbchelper.stringformatting.3.1"></a><img src="http://www.diveintopython.net/images/callouts/1.png" alt="1" border="0" width="12" height="12" />
-<span class="computeroutput">50.462500</span>
+<span class="computeroutput">Today's stock price: 50.462500</span>
 <tt class="prompt">&gt;&gt;&gt; </tt><span class="userinput"><span class="pykeyword">print</span> <span class="pystring">"Today's stock price: %.2f"</span> % 50.4625</span> <a name="odbchelper.stringformatting.3.2"></a><img src="http://www.diveintopython.net/images/callouts/2.png" alt="2" border="0" width="12" height="12" />
-<span class="computeroutput">50.46</span>
+<span class="computeroutput">Today's stock price: 50.46</span>
 <tt class="prompt">&gt;&gt;&gt; </tt><span class="userinput"><span class="pykeyword">print</span> <span class="pystring">"Change since yesterday: %+.2f"</span> % 1.5</span> <a name="odbchelper.stringformatting.3.3"></a><img src="http://www.diveintopython.net/images/callouts/3.png" alt="3" border="0" width="12" height="12" />
-<span class="computeroutput">+1.50</span>
+<span class="computeroutput">Change since yesterday: +1.50</span>
 </pre><div class="calloutlist">
 <table border="0" summary="Callout list">
 <tr>


### PR DESCRIPTION
Not sure if the "typo" was intentional on Pilgrim's part, but here's a fix if you want it.
